### PR TITLE
Add Menyoo intent API scaffolding

### DIFF
--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/Makefile
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/Makefile
@@ -6,11 +6,17 @@ AS		 := gcc
 OBJCOPY	 :=	objcopy
 ODIR	 :=	build
 SDIR	 :=	source
-IDIRS	 :=	-Iinclude
+IDIRS	 :=	-Iinclude -Isource/menyoo_compat
 LDIRS	 :=	-Llib
 CFLAGS	 :=	$(IDIRS) $(LDIRS) -O3 -s -w -std=gnu++11 -fno-builtin -nostartfiles -nostdlib -masm=intel -march=btver2 -mtune=btver2 -m64 -mabi=sysv -mcmodel=large -fpermissive -DTEXT_ADDRESS=$(TEXT) -DDATA_ADDRESS=$(DATA)
 LFLAGS	 :=	-Xlinker -T linker.x -Wl,--build-id=none -Ttext=$(TEXT) -Tdata=$(DATA)
-CFILES	 :=	$(wildcard $(SDIR)/*.cpp)
+CFILES	 :=	$(wildcard $(SDIR)/*.cpp) \
+                $(wildcard $(SDIR)/menyoo_compat/*.cpp)
+
+ifeq ($(MENUYO_TESTS),1)
+CFILES	 +=	$(wildcard $(SDIR)/tests/*.cpp)
+CFLAGS	 +=	-DMENUYO_TESTS=1
+endif
 SFILES	 :=	$(wildcard $(SDIR)/*.s)
 OBJS	 :=	$(patsubst $(SDIR)/%.cpp, $(ODIR)/%.o, $(CFILES)) $(patsubst $(SDIR)/%.s, $(ODIR)/%.o, $(SFILES))
 

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/include/Functions.h
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/include/Functions.h
@@ -1,3 +1,7 @@
+#include "menyoo/intent_api.hpp"
+
+extern bool GodModeVehicle1;
+
 char *ItoS(int num)
 {
 	char buf[30];
@@ -101,13 +105,23 @@ int FlyTakeOffDelay = 0;
 
 void Spawncar(char* model)
 {
-	FORCE_REQUEST_MODEL(GET_HASH_KEY(model));
-	if (HAS_MODEL_LOADED(GET_HASH_KEY(model))) {
-	vector3 coord = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
-	float Head = GET_ENTITY_HEADING(PLAYER_PED_ID());
-	int vehicle = CREATE_VEHICLE(GET_HASH_KEY(model), coord.x, coord.y, coord.z, Head, true, true, 1);
-	SET_PED_INTO_VEHICLE(PLAYER_PED_ID(), vehicle, -1);
-	}
+        vector3 coord = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
+        float heading = GET_ENTITY_HEADING(PLAYER_PED_ID());
+
+        menyoo::Transform transform{};
+        transform.pos = {coord.x, coord.y, coord.z};
+        transform.rot = {0.0f, 0.0f, heading};
+
+        menyoo::EntityId vehicleId = menyoo::spawn_entity(menyoo::EntityType::Vehicle, GET_HASH_KEY(model), transform);
+        if (vehicleId != 0) {
+                menyoo::set_entity_transform(vehicleId, transform);
+                menyoo::EntityProps props;
+                props.invincible = GodModeVehicle1;
+                props.frozen = GodModeVehicle1;
+                props.alpha = GodModeVehicle1 ? 200 : 255;
+                menyoo::set_entity_props(vehicleId, props);
+                SET_PED_INTO_VEHICLE(PLAYER_PED_ID(), vehicleId, -1);
+        }
 }
 
 void LOOP()

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/include/menyoo/intent_api.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/include/menyoo/intent_api.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace menyoo {
+
+struct Vec3 {
+        float x;
+        float y;
+        float z;
+};
+
+struct Transform {
+        Vec3 pos;
+        Vec3 rot;
+};
+
+enum class EntityType {
+        Ped,
+        Vehicle,
+        Object
+};
+
+using Hash = unsigned int;
+using EntityId = int;
+using VehicleId = int;
+using PedId = int;
+
+struct EntityProps {
+        bool visible = true;
+        bool collision = true;
+        bool invincible = false;
+        bool frozen = false;
+        int alpha = 255;
+};
+
+struct VehicleMods {
+        int engine = 0;
+        int brakes = 0;
+        int transmission = 0;
+        int suspension = 0;
+        int armor = 0;
+        int primaryColor = -1;
+        int secondaryColor = -1;
+        int pearlescent = -1;
+        int wheelColor = -1;
+        bool neon[4] = {false, false, false, false};
+        std::vector<int> extrasOn;
+};
+
+struct AttachSpec {
+        std::string bone;
+        Vec3 offset{};
+        Vec3 rot{};
+        bool softPin = false;
+        bool collisions = false;
+};
+
+EntityId spawn_entity(EntityType type, Hash model, const Transform& transform);
+void set_entity_transform(EntityId id, const Transform& transform);
+void set_entity_props(EntityId id, const EntityProps& props);
+void attach_entity(EntityId child, EntityId parent, const AttachSpec& spec);
+void apply_vehicle_mods(VehicleId vehicle, const VehicleMods& mods);
+
+bool save_map(const std::string& path);
+bool load_map(const std::string& path);
+
+bool capability_liveries();
+bool capability_complex_paths();
+
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.cpp
@@ -1,0 +1,155 @@
+#include "menyoo_compat/bridge_ps4.hpp"
+
+#include <algorithm>
+
+#include "natives.h"
+
+namespace menyoo {
+namespace {
+
+constexpr int kMaxModelTries = 100;
+
+bool ensure_model_loaded(Hash model) {
+        if (model == 0u) {
+                return false;
+        }
+        if (HAS_MODEL_LOADED(model)) {
+                return true;
+        }
+        for (int attempt = 0; attempt < kMaxModelTries; ++attempt) {
+                REQUEST_MODEL(model);
+                if (HAS_MODEL_LOADED(model)) {
+                        return true;
+                }
+                WAIT(0);
+        }
+        return HAS_MODEL_LOADED(model);
+}
+
+float heading_from_transform(const Transform& transform) {
+        return transform.rot.z;
+}
+
+} // namespace
+
+namespace bridge_ps4 {
+
+int spawn_vehicle(Hash model, const Transform& transform) {
+        if (!ensure_model_loaded(model)) {
+                return 0;
+        }
+        const auto& pos = transform.pos;
+        int handle = CREATE_VEHICLE(model, pos.x, pos.y, pos.z, heading_from_transform(transform), true, true, 1);
+        SET_MODEL_AS_NO_LONGER_NEEDED(model);
+        return handle;
+}
+
+int spawn_ped(Hash model, const Transform& transform) {
+        if (!ensure_model_loaded(model)) {
+                return 0;
+        }
+        const auto& pos = transform.pos;
+        int handle = CREATE_PED(26, model, pos.x, pos.y, pos.z, heading_from_transform(transform), true, true);
+        SET_MODEL_AS_NO_LONGER_NEEDED(model);
+        return handle;
+}
+
+int spawn_object(Hash model, const Transform& transform) {
+        if (!ensure_model_loaded(model)) {
+                return 0;
+        }
+        const auto& pos = transform.pos;
+        int handle = CREATE_OBJECT(model, pos.x, pos.y, pos.z, true, true, true);
+        SET_MODEL_AS_NO_LONGER_NEEDED(model);
+        return handle;
+}
+
+void set_entity_transform(int handle, const Transform& transform) {
+        const auto& pos = transform.pos;
+        const auto& rot = transform.rot;
+        SET_ENTITY_COORDS(handle, pos.x, pos.y, pos.z, false, false, false, true);
+        SET_ENTITY_ROTATION(handle, rot.x, rot.y, rot.z, 2, true);
+}
+
+void set_entity_props(int handle, const EntityProps& props) {
+        SET_ENTITY_VISIBLE(handle, props.visible, false);
+        SET_ENTITY_COLLISION(handle, props.collision, true);
+        SET_ENTITY_INVINCIBLE(handle, props.invincible);
+        FREEZE_ENTITY_POSITION(handle, props.frozen);
+        const int alpha = std::max(0, std::min(255, props.alpha));
+        SET_ENTITY_ALPHA(handle, alpha, props.visible);
+}
+
+void attach_entity(int childHandle, int parentHandle, EntityType childType, EntityType parentType, const AttachSpec& spec) {
+        int boneIndex = 0;
+        if (!spec.bone.empty()) {
+                boneIndex = GET_ENTITY_BONE_INDEX_BY_NAME(parentHandle, spec.bone.c_str());
+        }
+        ATTACH_ENTITY_TO_ENTITY(childHandle,
+                                parentHandle,
+                                boneIndex,
+                                spec.offset.x,
+                                spec.offset.y,
+                                spec.offset.z,
+                                spec.rot.x,
+                                spec.rot.y,
+                                spec.rot.z,
+                                false,
+                                spec.softPin,
+                                spec.collisions,
+                                childType == EntityType::Ped,
+                                0,
+                                true);
+}
+
+void apply_vehicle_mods(int vehicleHandle, const VehicleMods& mods) {
+        SET_VEHICLE_MOD_KIT(vehicleHandle, 0);
+        if (mods.engine >= 0) {
+                SET_VEHICLE_MOD(vehicleHandle, 11, mods.engine, false);
+        }
+        if (mods.brakes >= 0) {
+                SET_VEHICLE_MOD(vehicleHandle, 12, mods.brakes, false);
+        }
+        if (mods.transmission >= 0) {
+                SET_VEHICLE_MOD(vehicleHandle, 13, mods.transmission, false);
+        }
+        if (mods.suspension >= 0) {
+                SET_VEHICLE_MOD(vehicleHandle, 15, mods.suspension, false);
+        }
+        if (mods.armor >= 0) {
+                SET_VEHICLE_MOD(vehicleHandle, 16, mods.armor, false);
+        }
+        if (mods.primaryColor >= 0 && mods.secondaryColor >= 0) {
+                SET_VEHICLE_COLOURS(vehicleHandle, mods.primaryColor, mods.secondaryColor);
+        }
+        if (mods.pearlescent >= 0 || mods.wheelColor >= 0) {
+                int pearl = mods.pearlescent >= 0 ? mods.pearlescent : 0;
+                int wheel = mods.wheelColor >= 0 ? mods.wheelColor : 0;
+                SET_VEHICLE_EXTRA_COLOURS(vehicleHandle, pearl, wheel);
+        }
+        for (int i = 0; i < 4; ++i) {
+                _SET_VEHICLE_NEON_LIGHT_ENABLED(vehicleHandle, i, mods.neon[i]);
+        }
+        for (int extra : mods.extrasOn) {
+                SET_VEHICLE_EXTRA(vehicleHandle, extra, false);
+        }
+}
+
+bool save_map(const std::string&) {
+        return false;
+}
+
+bool load_map(const std::string&) {
+        return false;
+}
+
+bool capability_liveries() {
+        return false;
+}
+
+bool capability_complex_paths() {
+        return false;
+}
+
+} // namespace bridge_ps4
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+#include "menyoo/intent_api.hpp"
+
+namespace menyoo {
+namespace bridge_ps4 {
+
+int spawn_vehicle(Hash model, const Transform& transform);
+int spawn_ped(Hash model, const Transform& transform);
+int spawn_object(Hash model, const Transform& transform);
+
+void set_entity_transform(int handle, const Transform& transform);
+void set_entity_props(int handle, const EntityProps& props);
+void attach_entity(int childHandle, int parentHandle, EntityType childType, EntityType parentType, const AttachSpec& spec);
+void apply_vehicle_mods(int vehicleHandle, const VehicleMods& mods);
+
+bool save_map(const std::string& path);
+bool load_map(const std::string& path);
+
+bool capability_liveries();
+bool capability_complex_paths();
+
+} // namespace bridge_ps4
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/graph.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/graph.cpp
@@ -1,0 +1,64 @@
+#include "menyoo_compat/graph.hpp"
+
+#include <unordered_map>
+
+namespace menyoo {
+namespace {
+
+struct InternalRecord {
+        EntityType type;
+        int handle;
+        Transform transform;
+        EntityProps props;
+};
+
+std::unordered_map<EntityId, InternalRecord> g_records;
+
+} // namespace
+
+namespace graph {
+
+EntityId add_entity(EntityType type, int handle, const Transform& transform, const EntityProps& props) {
+        if (handle == 0) {
+                return 0;
+        }
+        InternalRecord record{type, handle, transform, props};
+        g_records[handle] = record;
+        return handle;
+}
+
+bool get_entity(EntityId id, EntityRecord& outRecord) {
+        auto it = g_records.find(id);
+        if (it == g_records.end()) {
+                return false;
+        }
+        outRecord = {id, it->second.type, it->second.handle, it->second.transform, it->second.props};
+        return true;
+}
+
+void update_transform(EntityId id, const Transform& transform) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                it->second.transform = transform;
+        }
+}
+
+void update_props(EntityId id, const EntityProps& props) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                it->second.props = props;
+        }
+}
+
+std::vector<EntityRecord> snapshot() {
+        std::vector<EntityRecord> result;
+        result.reserve(g_records.size());
+        for (const auto& pair : g_records) {
+                const auto& value = pair.second;
+                result.push_back({pair.first, value.type, value.handle, value.transform, value.props});
+        }
+        return result;
+}
+
+} // namespace graph
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/graph.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/graph.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <vector>
+
+#include "menyoo/intent_api.hpp"
+
+namespace menyoo {
+namespace graph {
+
+struct EntityRecord {
+        EntityId id;
+        EntityType type;
+        int handle;
+        Transform transform;
+        EntityProps props;
+};
+
+EntityId add_entity(EntityType type, int handle, const Transform& transform, const EntityProps& props);
+bool get_entity(EntityId id, EntityRecord& outRecord);
+void update_transform(EntityId id, const Transform& transform);
+void update_props(EntityId id, const EntityProps& props);
+std::vector<EntityRecord> snapshot();
+
+} // namespace graph
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/intent_api.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/intent_api.cpp
@@ -1,0 +1,99 @@
+#include "menyoo/intent_api.hpp"
+
+#include "menyoo_compat/bridge_ps4.hpp"
+#include "menyoo_compat/graph.hpp"
+#include "menyoo_compat/serializer_menyoo_xml.hpp"
+
+namespace menyoo {
+
+namespace {
+
+EntityProps default_props_for_type(EntityType) {
+        return EntityProps{};
+}
+
+} // namespace
+
+EntityId spawn_entity(EntityType type, Hash model, const Transform& transform) {
+        int handle = 0;
+        switch (type) {
+        case EntityType::Vehicle:
+                handle = bridge_ps4::spawn_vehicle(model, transform);
+                break;
+        case EntityType::Ped:
+                handle = bridge_ps4::spawn_ped(model, transform);
+                break;
+        case EntityType::Object:
+                handle = bridge_ps4::spawn_object(model, transform);
+                break;
+        }
+
+        if (handle == 0) {
+                return 0;
+        }
+
+        EntityProps props = default_props_for_type(type);
+        bridge_ps4::set_entity_transform(handle, transform);
+        bridge_ps4::set_entity_props(handle, props);
+        return graph::add_entity(type, handle, transform, props);
+}
+
+void set_entity_transform(EntityId id, const Transform& transform) {
+        graph::EntityRecord record{};
+        if (!graph::get_entity(id, record)) {
+                return;
+        }
+        bridge_ps4::set_entity_transform(record.handle, transform);
+        graph::update_transform(id, transform);
+}
+
+void set_entity_props(EntityId id, const EntityProps& props) {
+        graph::EntityRecord record{};
+        if (!graph::get_entity(id, record)) {
+                return;
+        }
+        bridge_ps4::set_entity_props(record.handle, props);
+        graph::update_props(id, props);
+}
+
+void attach_entity(EntityId child, EntityId parent, const AttachSpec& spec) {
+        graph::EntityRecord childRecord{};
+        graph::EntityRecord parentRecord{};
+        if (!graph::get_entity(child, childRecord)) {
+                return;
+        }
+        if (!graph::get_entity(parent, parentRecord)) {
+                return;
+        }
+        bridge_ps4::attach_entity(childRecord.handle, parentRecord.handle, childRecord.type, parentRecord.type, spec);
+}
+
+void apply_vehicle_mods(VehicleId vehicle, const VehicleMods& mods) {
+        graph::EntityRecord record{};
+        if (!graph::get_entity(vehicle, record)) {
+                return;
+        }
+        if (record.type != EntityType::Vehicle) {
+                return;
+        }
+        bridge_ps4::apply_vehicle_mods(record.handle, mods);
+}
+
+bool save_map(const std::string& path) {
+        return serializer::save_map(path, graph::snapshot());
+}
+
+bool load_map(const std::string& path) {
+        auto entities = graph::snapshot();
+        return serializer::load_map(path, entities);
+}
+
+bool capability_liveries() {
+        return bridge_ps4::capability_liveries();
+}
+
+bool capability_complex_paths() {
+        return bridge_ps4::capability_complex_paths();
+}
+
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.cpp
@@ -1,0 +1,15 @@
+#include "menyoo_compat/serializer_menyoo_xml.hpp"
+
+namespace menyoo {
+namespace serializer {
+
+bool save_map(const std::string&, const std::vector<graph::EntityRecord>&) {
+        return false; // TODO: Implement Menyoo XML export.
+}
+
+bool load_map(const std::string&, std::vector<graph::EntityRecord>&) {
+        return false; // TODO: Implement Menyoo XML import.
+}
+
+} // namespace serializer
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "menyoo_compat/graph.hpp"
+
+namespace menyoo {
+namespace serializer {
+
+bool save_map(const std::string& path, const std::vector<graph::EntityRecord>& entities);
+bool load_map(const std::string& path, std::vector<graph::EntityRecord>& entities);
+
+} // namespace serializer
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/tests/spooner_min.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/tests/spooner_min.cpp
@@ -1,0 +1,45 @@
+#if MENUYO_TESTS
+
+#include "menyoo/intent_api.hpp"
+
+namespace {
+
+constexpr menyoo::Hash kAdderHash = 0xB779A091;
+constexpr menyoo::Hash kPropHash = 0x5D6B5F0B;
+
+} // namespace
+
+extern "C" void run_spooner_min_test() {
+        using namespace menyoo;
+
+        Transform vehicleTransform{};
+        vehicleTransform.pos = {0.0f, 0.0f, 75.0f};
+        vehicleTransform.rot = {0.0f, 0.0f, 0.0f};
+        EntityId vehicleId = spawn_entity(EntityType::Vehicle, kAdderHash, vehicleTransform);
+        if (vehicleId == 0) {
+                return;
+        }
+        set_entity_transform(vehicleId, vehicleTransform);
+
+        Transform propTransform{};
+        propTransform.pos = {0.0f, 0.0f, 75.0f};
+        propTransform.rot = {0.0f, 0.0f, 0.0f};
+        EntityId propId = spawn_entity(EntityType::Object, kPropHash, propTransform);
+        if (propId != 0) {
+                AttachSpec spec;
+                spec.bone = "chassis";
+                spec.offset = {0.0f, 1.0f, 0.4f};
+                attach_entity(propId, vehicleId, spec);
+        }
+
+        EntityProps props;
+        props.invincible = true;
+        props.frozen = true;
+        props.alpha = 200;
+        set_entity_props(vehicleId, props);
+
+        save_map("tmp_map.xml");
+        load_map("tmp_map.xml");
+}
+
+#endif // MENUYO_TESTS


### PR DESCRIPTION
## Summary
- add a Menyoo intent API surface along with graph, bridge, and serializer scaffolding
- route the vehicle spawner through the intent API and expose capability hooks
- add a stubbed Spooner regression test and build system wiring for optional runs

## Testing
- not run (PS4 toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e12e1c4ff0833186125f16d849f7af