### PR TITLE
Implement Spooner intent API and menu

### DIFF
--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/Makefile
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/Makefile
@@ -6,11 +6,18 @@ AS		 := gcc
 OBJCOPY	 :=	objcopy
 ODIR	 :=	build
 SDIR	 :=	source
-IDIRS	 :=	-Iinclude
+IDIRS	 :=	-Iinclude -Isource/menyoo_compat
 LDIRS	 :=	-Llib
 CFLAGS	 :=	$(IDIRS) $(LDIRS) -O3 -s -w -std=gnu++11 -fno-builtin -nostartfiles -nostdlib -masm=intel -march=btver2 -mtune=btver2 -m64 -mabi=sysv -mcmodel=large -fpermissive -DTEXT_ADDRESS=$(TEXT) -DDATA_ADDRESS=$(DATA)
 LFLAGS	 :=	-Xlinker -T linker.x -Wl,--build-id=none -Ttext=$(TEXT) -Tdata=$(DATA)
-CFILES	 :=	$(wildcard $(SDIR)/*.cpp)
+CFILES   :=     $(wildcard $(SDIR)/*.cpp) \
+	        $(wildcard $(SDIR)/menyoo_compat/*.cpp) \
+	        $(wildcard $(SDIR)/ui/*.cpp)
+
+ifeq ($(MENUYO_TESTS),1)
+CFILES	 +=	$(wildcard $(SDIR)/tests/*.cpp)
+CFLAGS	 +=	-DMENUYO_TESTS=1
+endif
 SFILES	 :=	$(wildcard $(SDIR)/*.s)
 OBJS	 :=	$(patsubst $(SDIR)/%.cpp, $(ODIR)/%.o, $(CFILES)) $(patsubst $(SDIR)/%.s, $(ODIR)/%.o, $(SFILES))
 
@@ -22,9 +29,11 @@ $(TARGET): $(ODIR) $(OBJS)
 	rm -f temp.t
 
 $(ODIR)/%.o: $(SDIR)/%.cpp
+	@mkdir -p $(dir $@)
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 $(ODIR)/%.o: $(SDIR)/%.s
+	@mkdir -p $(dir $@)
 	$(AS) -c -o $@ $< $(SFLAGS)
 
 $(ODIR):

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/include/Functions.h
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/include/Functions.h
@@ -1,3 +1,7 @@
+#include "menyoo/intent_api.hpp"
+
+extern bool GodModeVehicle1;
+
 char *ItoS(int num)
 {
 	char buf[30];
@@ -101,13 +105,23 @@ int FlyTakeOffDelay = 0;
 
 void Spawncar(char* model)
 {
-	FORCE_REQUEST_MODEL(GET_HASH_KEY(model));
-	if (HAS_MODEL_LOADED(GET_HASH_KEY(model))) {
-	vector3 coord = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
-	float Head = GET_ENTITY_HEADING(PLAYER_PED_ID());
-	int vehicle = CREATE_VEHICLE(GET_HASH_KEY(model), coord.x, coord.y, coord.z, Head, true, true, 1);
-	SET_PED_INTO_VEHICLE(PLAYER_PED_ID(), vehicle, -1);
-	}
+        vector3 coord = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
+        float heading = GET_ENTITY_HEADING(PLAYER_PED_ID());
+
+        menyoo::Transform transform{};
+        transform.pos = {coord.x, coord.y, coord.z};
+        transform.rot = {0.0f, 0.0f, heading};
+
+        menyoo::EntityId vehicleId = menyoo::spawn_entity(menyoo::EntityType::Vehicle, GET_HASH_KEY(model), transform);
+        if (vehicleId != 0) {
+                menyoo::set_entity_transform(vehicleId, transform);
+                menyoo::EntityProps props;
+                props.invincible = GodModeVehicle1;
+                props.frozen = GodModeVehicle1;
+                props.alpha = GodModeVehicle1 ? 200 : 255;
+                menyoo::set_entity_props(vehicleId, props);
+                SET_PED_INTO_VEHICLE(PLAYER_PED_ID(), vehicleId, -1);
+        }
 }
 
 void LOOP()

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/include/MenuUtils.h
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/include/MenuUtils.h
@@ -62,6 +62,8 @@ fastLPress = false,
 
 WhiteColor,
 WhiteColor_toggle;
+
+namespace menyoo { namespace ui { bool HandleSpoonerControls(); } }
 char* CreditText = " ";
 int TextTimer = 0,
 CreditTextTimer = 0,
@@ -99,6 +101,7 @@ enum Subs
 	SettingsOptions,
 	Credits,
 	PopularTP,
+	Spooner_Menu,
 };
 
 int SetGlobal(unsigned int globalId, int value, int wouldRead)
@@ -486,6 +489,10 @@ void SetupButtons()
 	else
 	{
 		SET_PED_CAN_SWITCH_WEAPON(PLAYER_PED_ID(), false);
+		bool spoonerConsumed = false;
+		if (NumMenu == Spooner_Menu) {
+			spoonerConsumed = menyoo::ui::HandleSpoonerControls();
+		}
 		if (IS_DISABLED_CONTROL_JUST_PRESSED(2, INPUT_FRONTEND_CANCEL))
 		{
 			if (NumMenu == Main_Menu)
@@ -512,7 +519,7 @@ void SetupButtons()
 			PressX = true;
 			PLAY_SOUND_FRONTEND(-1, "FLIGHT_SCHOOL_LESSON_PASSED", "HUD_AWARDS", 1.0);
 		}
-		else if (delayed_key_press(INPUT_FRONTEND_UP) == true)
+		else if (!spoonerConsumed && delayed_key_press(INPUT_FRONTEND_UP) == true)
 		{
 			currentOption--;
 			if (currentOption < 1)
@@ -521,7 +528,7 @@ void SetupButtons()
 			}
 			PLAY_SOUND_FRONTEND(-1, "NAV_UP_DOWN", "HUD_FRONTEND_DEFAULT_SOUNDSET", 1.0);
 		}
-		else if (delayed_key_press(INPUT_FRONTEND_DOWN) == true)
+		else if (!spoonerConsumed && delayed_key_press(INPUT_FRONTEND_DOWN) == true)
 		{
 			currentOption++;
 			if (currentOption > optionCount)
@@ -530,12 +537,12 @@ void SetupButtons()
 			}
 			PLAY_SOUND_FRONTEND(-1, "NAV_UP_DOWN", "HUD_FRONTEND_DEFAULT_SOUNDSET", 1.0);
 		}
-		else if (delayed_key_press(INPUT_FRONTEND_RIGHT) == true)
+		else if (!spoonerConsumed && delayed_key_press(INPUT_FRONTEND_RIGHT) == true)
 		{
 			rightPress = true;
 			PLAY_SOUND_FRONTEND(-1, "NAV_LEFT_RIGHT", "HUD_FRONTEND_DEFAULT_SOUNDSET", 1.0);
 		}
-		else if (delayed_key_press(INPUT_FRONTEND_LEFT) == true)
+		else if (!spoonerConsumed && delayed_key_press(INPUT_FRONTEND_LEFT) == true)
 		{
 			leftPress = true;
 			PLAY_SOUND_FRONTEND(-1, "NAV_LEFT_RIGHT", "HUD_FRONTEND_DEFAULT_SOUNDSET", 1.0);

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/include/menyoo/intent_api.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/include/menyoo/intent_api.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "menyoo/spooner.hpp"

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/include/menyoo/spooner.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/include/menyoo/spooner.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace menyoo {
+
+struct Vec3 {
+        float x;
+        float y;
+        float z;
+
+        Vec3() : x(0.0f), y(0.0f), z(0.0f) {}
+        Vec3(float ix, float iy, float iz) : x(ix), y(iy), z(iz) {}
+};
+
+struct Transform {
+        Vec3 pos;
+        Vec3 rot;
+
+        Transform() = default;
+        Transform(const Vec3& position, const Vec3& rotation) : pos(position), rot(rotation) {}
+};
+
+enum class EntityType {
+        Ped,
+        Vehicle,
+        Object
+};
+
+using Hash = unsigned int;
+using EntityId = int;
+using VehicleId = int;
+using PedId = int;
+
+struct EntityProps {
+        bool visible = true;
+        bool collision = true;
+        bool invincible = false;
+        bool frozen = false;
+        int alpha = 255;
+};
+
+struct VehicleMods {
+        int primaryColor = -1;
+        int secondaryColor = -1;
+        int pearlescent = -1;
+        int wheelColor = -1;
+        bool neon[4] = {false, false, false, false};
+        std::vector<int> extrasOn;
+};
+
+struct AttachSpec {
+        std::string bone;
+        Vec3 offset{};
+        Vec3 rot{};
+        bool collisions = false;
+        bool softPin = false;
+};
+
+struct AttachmentInfo {
+        bool attached = false;
+        EntityId parent = 0;
+        AttachSpec spec{};
+};
+
+EntityId spawn_entity(EntityType type, Hash model, const Transform& transform);
+void set_entity_transform(EntityId id, const Transform& transform);
+Transform get_entity_transform(EntityId id);
+void set_entity_props(EntityId id, const EntityProps& props);
+EntityProps get_entity_props(EntityId id);
+void attach_entity(EntityId child, EntityId parent, const AttachSpec& spec);
+void detach_entity(EntityId child);
+bool delete_entity(EntityId id);
+
+std::vector<EntityId> list_entities();
+bool is_valid(EntityId id);
+EntityType entity_type(EntityId id);
+Hash entity_model(EntityId id);
+AttachmentInfo get_attachment(EntityId id);
+
+bool save_map(const char* path);
+bool load_map(const char* path);
+
+bool capability_liveries();
+bool capability_complex_paths();
+
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/include/ui/page_spooner.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/include/ui/page_spooner.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace menyoo {
+namespace ui {
+
+void DrawSpoonerMenu();
+bool HandleSpoonerControls();
+
+} // namespace ui
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/main.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/main.cpp
@@ -4,6 +4,7 @@
 #include "Enums.h"
 #include "MenuUtils.h"
 #include "Functions.h"
+#include "ui/page_spooner.hpp"
 
 
 
@@ -46,20 +47,22 @@ void Menu(void)
 		addOption("Weapons Options");
 		addOption("Vehicle Spawner");
 		addOption("Vehicle Options");
-		addOption("Teleport Options");
-		addOption("World Options");
-		addOption("Setting Options");
-		switch (GET())
-		{
-			case 1: ChangeMenu(Main_Mods); break;
-			case 2: ChangeMenu(Weapons); break;
-			case 3: ChangeMenu(spawnvehicle); break;
-			 case 4:  if (IS_PED_IN_ANY_VEHICLE(PLAYER_PED_ID(), true)) { ChangeMenu(Vehicle_Options); } else { drawNotification("~y~Must Be In Vehicle To Open Vehicle Options Menu"); }break;
-			case 5: ChangeMenu(Teleport); break;
-			case 6: ChangeMenu(World_Options); break;
-			case 7: ChangeMenu(SettingsOptions); break;
-		}
-		break;
+                addOption("Teleport Options");
+                addOption("World Options");
+                addOption("Setting Options");
+                addOption("Spooner");
+                switch (GET())
+                {
+                        case 1: ChangeMenu(Main_Mods); break;
+                        case 2: ChangeMenu(Weapons); break;
+                        case 3: ChangeMenu(spawnvehicle); break;
+                         case 4:  if (IS_PED_IN_ANY_VEHICLE(PLAYER_PED_ID(), true)) { ChangeMenu(Vehicle_Options); } else { drawNotification("~y~Must Be In Vehicle To Open Vehicle Options Menu"); }break;
+                        case 5: ChangeMenu(Teleport); break;
+                        case 6: ChangeMenu(World_Options); break;
+                        case 7: ChangeMenu(SettingsOptions); break;
+                        case 8: ChangeMenu(Spooner_Menu); break;
+                }
+                break;
 		case Main_Mods:
 		subTitle("Self Options");
 		CheckBox("God Mode", UndetectableGodmode);
@@ -142,18 +145,21 @@ void Menu(void)
 		{
 		}
 		break;
-		case Credits: ///Please Keep Menu Credits!
-		subTitle("Credits Options");
+                case Credits: ///Please Keep Menu Credits!
+                subTitle("Credits Options");
         addOption("~r~ Developer: YOUR NAME~r~");
-		addOption("~b~ Menu Base: Lush Modz ~b~"); //Keep Here
-		addOption("~r~ 1.38: GraFfiX_221211 ~r~"); //Keep Here
-		addOption("~y~ V1.0 ~b~");
-		switch (GET())
-		{
-			case 1: /*MODS*/ break;
-		}
-		break;
-	}
+                addOption("~b~ Menu Base: Lush Modz ~b~"); //Keep Here
+                addOption("~r~ 1.38: GraFfiX_221211 ~r~"); //Keep Here
+                addOption("~y~ V1.0 ~b~");
+                switch (GET())
+                {
+                        case 1: /*MODS*/ break;
+                }
+                break;
+                case Spooner_Menu:
+                menyoo::ui::DrawSpoonerMenu();
+                break;
+        }
 	Setup_System();
 	if (NumMenu != Closed)
 	SetupActions();

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.cpp
@@ -1,0 +1,183 @@
+#include "bridge_ps4.hpp"
+
+#include <algorithm>
+
+#include "natives.h"
+
+namespace menyoo {
+namespace {
+
+constexpr int kMaxModelTries = 100;
+
+bool ensure_model_loaded(Hash model) {
+        if (model == 0u) {
+                return false;
+        }
+        if (HAS_MODEL_LOADED(model)) {
+                return true;
+        }
+        for (int attempt = 0; attempt < kMaxModelTries; ++attempt) {
+                REQUEST_MODEL(model);
+                if (HAS_MODEL_LOADED(model)) {
+                        return true;
+                }
+                WAIT(0);
+        }
+        return HAS_MODEL_LOADED(model);
+}
+
+float heading_from_transform(const Transform& transform) {
+        return transform.rot.z;
+}
+
+void apply_proofs(int handle, bool enabled) {
+        SET_ENTITY_PROOFS(handle, enabled, enabled, enabled, enabled, enabled, enabled, enabled, enabled);
+        SET_ENTITY_CAN_BE_DAMAGED(handle, !enabled);
+        SET_ENTITY_INVINCIBLE(handle, enabled);
+}
+
+} // namespace
+
+namespace bridge_ps4 {
+
+int spawn_vehicle(Hash model, const Transform& transform) {
+        if (!ensure_model_loaded(model)) {
+                return 0;
+        }
+        const auto& pos = transform.pos;
+        int handle = CREATE_VEHICLE(model, pos.x, pos.y, pos.z, heading_from_transform(transform), true, true, 1);
+        SET_MODEL_AS_NO_LONGER_NEEDED(model);
+        return handle;
+}
+
+int spawn_ped(Hash model, const Transform& transform) {
+        if (!ensure_model_loaded(model)) {
+                return 0;
+        }
+        const auto& pos = transform.pos;
+        int handle = CREATE_PED(26, model, pos.x, pos.y, pos.z, heading_from_transform(transform), true, true);
+        SET_MODEL_AS_NO_LONGER_NEEDED(model);
+        return handle;
+}
+
+int spawn_object(Hash model, const Transform& transform) {
+        if (!ensure_model_loaded(model)) {
+                return 0;
+        }
+        const auto& pos = transform.pos;
+        int handle = CREATE_OBJECT(model, pos.x, pos.y, pos.z, true, true, true);
+        SET_MODEL_AS_NO_LONGER_NEEDED(model);
+        return handle;
+}
+
+void set_entity_transform(int handle, const Transform& transform) {
+        const auto& pos = transform.pos;
+        const auto& rot = transform.rot;
+        SET_ENTITY_COORDS(handle, pos.x, pos.y, pos.z, false, false, false, true);
+        SET_ENTITY_ROTATION(handle, rot.x, rot.y, rot.z, 2, true);
+}
+
+void set_entity_props(int handle, const EntityProps& props) {
+        SET_ENTITY_VISIBLE(handle, props.visible, false);
+        SET_ENTITY_COLLISION(handle, props.collision, true);
+        apply_proofs(handle, props.invincible);
+        FREEZE_ENTITY_POSITION(handle, props.frozen);
+        const int alpha = std::max(0, std::min(255, props.alpha));
+        SET_ENTITY_ALPHA(handle, alpha, props.visible);
+}
+
+EntityProps get_entity_props(int handle) {
+        EntityProps props{};
+        props.visible = IS_ENTITY_VISIBLE(handle);
+        props.collision = !GET_ENTITY_COLLISION_DISABLED(handle);
+        props.invincible = !_GET_ENTITY_CAN_BE_DAMAGED(handle);
+        props.alpha = GET_ENTITY_ALPHA(handle);
+        props.frozen = false;
+        return props;
+}
+
+Transform get_entity_transform(int handle) {
+        Transform transform{};
+        vector3 pos = GET_ENTITY_COORDS(handle, true);
+        vector3 rot = GET_ENTITY_ROTATION(handle, 2);
+        transform.pos = {pos.x, pos.y, pos.z};
+        transform.rot = {rot.x, rot.y, rot.z};
+        return transform;
+}
+
+void attach_entity(int childHandle, int parentHandle, EntityType childType, EntityType parentType, const AttachSpec& spec) {
+        int boneIndex = 0;
+        if (!spec.bone.empty()) {
+                boneIndex = GET_ENTITY_BONE_INDEX_BY_NAME(parentHandle, spec.bone.c_str());
+        }
+        ATTACH_ENTITY_TO_ENTITY(childHandle,
+                                parentHandle,
+                                boneIndex,
+                                spec.offset.x,
+                                spec.offset.y,
+                                spec.offset.z,
+                                spec.rot.x,
+                                spec.rot.y,
+                                spec.rot.z,
+                                false,
+                                spec.softPin,
+                                spec.collisions,
+                                childType == EntityType::Ped,
+                                0,
+                                true);
+}
+
+void detach_entity(int childHandle) {
+        DETACH_ENTITY(childHandle, true, true);
+}
+
+bool delete_entity(int handle) {
+        if (!DOES_ENTITY_EXIST(handle)) {
+                return false;
+        }
+        SET_ENTITY_AS_MISSION_ENTITY(handle, true, true);
+        int entity = handle;
+        DELETE_ENTITY(&entity);
+        return true;
+}
+
+bool entity_exists(int handle) {
+        return DOES_ENTITY_EXIST(handle);
+}
+
+void apply_vehicle_mods(int vehicleHandle, const VehicleMods& mods) {
+        SET_VEHICLE_MOD_KIT(vehicleHandle, 0);
+        if (mods.primaryColor >= 0 && mods.secondaryColor >= 0) {
+                SET_VEHICLE_COLOURS(vehicleHandle, mods.primaryColor, mods.secondaryColor);
+        }
+        if (mods.pearlescent >= 0 || mods.wheelColor >= 0) {
+                int pearl = mods.pearlescent >= 0 ? mods.pearlescent : 0;
+                int wheel = mods.wheelColor >= 0 ? mods.wheelColor : 0;
+                SET_VEHICLE_EXTRA_COLOURS(vehicleHandle, pearl, wheel);
+        }
+        for (int i = 0; i < 4; ++i) {
+                _SET_VEHICLE_NEON_LIGHT_ENABLED(vehicleHandle, i, mods.neon[i]);
+        }
+        for (int extra : mods.extrasOn) {
+                SET_VEHICLE_EXTRA(vehicleHandle, extra, false);
+        }
+}
+
+bool save_map(const char*) {
+        return false;
+}
+
+bool load_map(const char*) {
+        return false;
+}
+
+bool capability_liveries() {
+        return false;
+}
+
+bool capability_complex_paths() {
+        return false;
+}
+
+} // namespace bridge_ps4
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/bridge_ps4.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+#include "menyoo/spooner.hpp"
+
+namespace menyoo {
+namespace bridge_ps4 {
+
+int spawn_vehicle(Hash model, const Transform& transform);
+int spawn_ped(Hash model, const Transform& transform);
+int spawn_object(Hash model, const Transform& transform);
+
+void set_entity_transform(int handle, const Transform& transform);
+void set_entity_props(int handle, const EntityProps& props);
+EntityProps get_entity_props(int handle);
+Transform get_entity_transform(int handle);
+void attach_entity(int childHandle, int parentHandle, EntityType childType, EntityType parentType, const AttachSpec& spec);
+void detach_entity(int childHandle);
+bool delete_entity(int handle);
+bool entity_exists(int handle);
+void apply_vehicle_mods(int vehicleHandle, const VehicleMods& mods);
+
+bool save_map(const char* path);
+bool load_map(const char* path);
+
+bool capability_liveries();
+bool capability_complex_paths();
+
+} // namespace bridge_ps4
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/intent_api.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/intent_api.cpp
@@ -1,0 +1,188 @@
+#include "menyoo/intent_api.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "bridge_ps4.hpp"
+#include "serializer_menyoo_xml.hpp"
+#include "spooner_graph.hpp"
+
+namespace menyoo {
+namespace {
+
+EntityProps default_props_for_type(EntityType) {
+        return EntityProps{};
+}
+
+} // namespace
+
+EntityId spawn_entity(EntityType type, Hash model, const Transform& transform) {
+        int handle = 0;
+        switch (type) {
+        case EntityType::Vehicle:
+                handle = bridge_ps4::spawn_vehicle(model, transform);
+                break;
+        case EntityType::Ped:
+                handle = bridge_ps4::spawn_ped(model, transform);
+                break;
+        case EntityType::Object:
+                handle = bridge_ps4::spawn_object(model, transform);
+                break;
+        }
+        if (handle == 0) {
+                return 0;
+        }
+        EntityProps props = default_props_for_type(type);
+        bridge_ps4::set_entity_transform(handle, transform);
+        bridge_ps4::set_entity_props(handle, props);
+        return spooner_graph::add_entity(type, model, handle, transform, props);
+}
+
+void set_entity_transform(EntityId id, const Transform& transform) {
+        spooner_graph::EntityRecord record{};
+        if (!spooner_graph::get_entity(id, record)) {
+                return;
+        }
+        bridge_ps4::set_entity_transform(record.handle, transform);
+        spooner_graph::update_transform(id, transform);
+}
+
+Transform get_entity_transform(EntityId id) {
+        spooner_graph::EntityRecord record{};
+        if (!spooner_graph::get_entity(id, record)) {
+                return Transform{};
+        }
+        Transform transform = bridge_ps4::get_entity_transform(record.handle);
+        spooner_graph::update_transform(id, transform);
+        return transform;
+}
+
+void set_entity_props(EntityId id, const EntityProps& props) {
+        spooner_graph::EntityRecord record{};
+        if (!spooner_graph::get_entity(id, record)) {
+                return;
+        }
+        bridge_ps4::set_entity_props(record.handle, props);
+        spooner_graph::update_props(id, props);
+}
+
+EntityProps get_entity_props(EntityId id) {
+        spooner_graph::EntityRecord record{};
+        if (!spooner_graph::get_entity(id, record)) {
+                return EntityProps{};
+        }
+        EntityProps props = bridge_ps4::get_entity_props(record.handle);
+        props.frozen = record.props.frozen;
+        spooner_graph::update_props(id, props);
+        return props;
+}
+
+void attach_entity(EntityId child, EntityId parent, const AttachSpec& spec) {
+        spooner_graph::EntityRecord childRecord{};
+        spooner_graph::EntityRecord parentRecord{};
+        if (!spooner_graph::get_entity(child, childRecord)) {
+                return;
+        }
+        if (!spooner_graph::get_entity(parent, parentRecord)) {
+                return;
+        }
+        bridge_ps4::attach_entity(childRecord.handle, parentRecord.handle, childRecord.type, parentRecord.type, spec);
+        spooner_graph::update_attachment(child, parent, spec);
+}
+
+void detach_entity(EntityId child) {
+        spooner_graph::EntityRecord childRecord{};
+        if (!spooner_graph::get_entity(child, childRecord)) {
+                return;
+        }
+        bridge_ps4::detach_entity(childRecord.handle);
+        spooner_graph::clear_attachment(child);
+}
+
+bool delete_entity(EntityId id) {
+        spooner_graph::EntityRecord record{};
+        if (!spooner_graph::get_entity(id, record)) {
+                return false;
+        }
+        if (!bridge_ps4::delete_entity(record.handle)) {
+                return false;
+        }
+        spooner_graph::remove_entity(id);
+        return true;
+}
+
+std::vector<EntityId> list_entities() {
+        std::vector<EntityId> ids = spooner_graph::list_entities();
+        ids.erase(std::remove_if(ids.begin(), ids.end(), [](EntityId id) {
+                if (!bridge_ps4::entity_exists(id)) {
+                        spooner_graph::remove_entity(id);
+                        return true;
+                }
+                return false;
+        }), ids.end());
+        return ids;
+}
+
+bool is_valid(EntityId id) {
+        if (!spooner_graph::has_entity(id)) {
+                return false;
+        }
+        return bridge_ps4::entity_exists(id);
+}
+
+EntityType entity_type(EntityId id) {
+        return spooner_graph::type(id);
+}
+
+Hash entity_model(EntityId id) {
+        return spooner_graph::model(id);
+}
+
+AttachmentInfo get_attachment(EntityId id) {
+        return spooner_graph::attachment(id);
+}
+
+bool save_map(const char* path) {
+        return serializer::save_map(path, spooner_graph::snapshot());
+}
+
+bool load_map(const char* path) {
+        std::vector<serializer::LoadedEntity> loaded;
+        if (!serializer::load_map(path, loaded)) {
+                return false;
+        }
+        std::unordered_map<EntityId, EntityId> idMap;
+        for (const auto& entry : loaded) {
+                EntityId newId = spawn_entity(entry.type, entry.model, entry.transform);
+                if (newId == 0) {
+                        continue;
+                }
+                set_entity_props(newId, entry.props);
+                if (entry.type == EntityType::Vehicle) {
+                        spooner_graph::set_vehicle_mods(newId, entry.vehicleMods);
+                        bridge_ps4::apply_vehicle_mods(newId, entry.vehicleMods);
+                }
+                idMap[entry.legacyId] = newId;
+        }
+        for (const auto& entry : loaded) {
+                if (!entry.attachment.attached) {
+                        continue;
+                }
+                auto childIt = idMap.find(entry.legacyId);
+                auto parentIt = idMap.find(entry.attachment.parent);
+                if (childIt != idMap.end() && parentIt != idMap.end()) {
+                        attach_entity(childIt->second, parentIt->second, entry.attachment.spec);
+                }
+        }
+        return !loaded.empty();
+}
+
+bool capability_liveries() {
+        return bridge_ps4::capability_liveries();
+}
+
+bool capability_complex_paths() {
+        return bridge_ps4::capability_complex_paths();
+}
+
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.cpp
@@ -1,0 +1,313 @@
+#include "serializer_menyoo_xml.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iterator>
+#include <sstream>
+
+namespace menyoo {
+namespace {
+
+std::string type_to_string(EntityType type) {
+        switch (type) {
+        case EntityType::Vehicle:
+                return "vehicle";
+        case EntityType::Ped:
+                return "ped";
+        case EntityType::Object:
+        default:
+                return "object";
+        }
+}
+
+EntityType type_from_string(const std::string& value) {
+        if (value == "vehicle") {
+                return EntityType::Vehicle;
+        }
+        if (value == "ped") {
+                return EntityType::Ped;
+        }
+        return EntityType::Object;
+}
+
+bool parse_bool(const std::string& value) {
+        if (value.empty()) {
+                return false;
+        }
+        if (value == "1") {
+                return true;
+        }
+        if (value == "0") {
+                return false;
+        }
+        std::string lowered = value;
+        for (char& ch : lowered) {
+                if (ch >= 'A' && ch <= 'Z') {
+                        ch = static_cast<char>(ch - 'A' + 'a');
+                }
+        }
+        return lowered == "true";
+}
+
+float parse_float(const std::string& value) {
+        return value.empty() ? 0.0f : static_cast<float>(std::atof(value.c_str()));
+}
+
+int parse_int(const std::string& value) {
+        if (value.empty()) {
+                return 0;
+        }
+        return std::atoi(value.c_str());
+}
+
+Hash parse_hash(const std::string& value) {
+        if (value.empty()) {
+                return 0;
+        }
+        if (value.size() > 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X')) {
+                return static_cast<Hash>(std::strtoul(value.c_str(), nullptr, 16));
+        }
+        return static_cast<Hash>(std::strtoul(value.c_str(), nullptr, 10));
+}
+
+std::string get_attribute(const std::string& tag, const char* attribute) {
+        std::string pattern = std::string(attribute) + "=\"";
+        auto start = tag.find(pattern);
+        if (start == std::string::npos) {
+                return std::string();
+        }
+        start += pattern.size();
+        auto end = tag.find('"', start);
+        if (end == std::string::npos) {
+                return std::string();
+        }
+        return tag.substr(start, end - start);
+}
+
+std::string get_tag_content(const std::string& block, const char* tag) {
+        std::string open = std::string("<") + tag + ">";
+        std::string close = std::string("</") + tag + ">";
+        auto start = block.find(open);
+        if (start == std::string::npos) {
+                return std::string();
+        }
+        start += open.size();
+        auto end = block.find(close, start);
+        if (end == std::string::npos) {
+                return std::string();
+        }
+        return block.substr(start, end - start);
+}
+
+std::string get_tag_segment(const std::string& block, const char* tag) {
+        std::string open = std::string("<") + tag;
+        auto start = block.find(open);
+        if (start == std::string::npos) {
+                return std::string();
+        }
+        auto end = block.find('>', start);
+        if (end == std::string::npos) {
+                return std::string();
+        }
+        return block.substr(start, end - start + 1);
+}
+
+void write_vehicle_mods(FILE* file, const VehicleMods& mods) {
+        bool hasExtras = !mods.extrasOn.empty();
+        bool hasColors = mods.primaryColor >= 0 || mods.secondaryColor >= 0 || mods.pearlescent >= 0 || mods.wheelColor >= 0;
+        bool hasNeon = std::any_of(std::begin(mods.neon), std::end(mods.neon), [](bool value) { return value; });
+        if (!hasExtras && !hasColors && !hasNeon) {
+                return;
+        }
+        std::fprintf(file,
+                     "    <VehicleMods primaryColor=\"%d\" secondaryColor=\"%d\" pearlescent=\"%d\" wheelColor=\"%d\" neon0=\"%d\" neon1=\"%d\" neon2=\"%d\" neon3=\"%d\">\n",
+                     mods.primaryColor,
+                     mods.secondaryColor,
+                     mods.pearlescent,
+                     mods.wheelColor,
+                     mods.neon[0] ? 1 : 0,
+                     mods.neon[1] ? 1 : 0,
+                     mods.neon[2] ? 1 : 0,
+                     mods.neon[3] ? 1 : 0);
+        std::fprintf(file, "      <Extras>");
+        for (size_t i = 0; i < mods.extrasOn.size(); ++i) {
+                std::fprintf(file, "%s%d", i == 0 ? "" : " ", mods.extrasOn[i]);
+        }
+        std::fprintf(file, "</Extras>\n");
+        std::fprintf(file, "    </VehicleMods>\n");
+}
+
+VehicleMods parse_vehicle_mods(const std::string& block) {
+        VehicleMods mods;
+        std::string segment = get_tag_segment(block, "VehicleMods");
+        if (segment.empty()) {
+                return mods;
+        }
+        mods.primaryColor = parse_int(get_attribute(segment, "primaryColor"));
+        mods.secondaryColor = parse_int(get_attribute(segment, "secondaryColor"));
+        mods.pearlescent = parse_int(get_attribute(segment, "pearlescent"));
+        mods.wheelColor = parse_int(get_attribute(segment, "wheelColor"));
+        mods.neon[0] = parse_bool(get_attribute(segment, "neon0"));
+        mods.neon[1] = parse_bool(get_attribute(segment, "neon1"));
+        mods.neon[2] = parse_bool(get_attribute(segment, "neon2"));
+        mods.neon[3] = parse_bool(get_attribute(segment, "neon3"));
+        std::string extrasContent = get_tag_content(block, "Extras");
+        if (!extrasContent.empty()) {
+                std::istringstream stream(extrasContent);
+                int extra = 0;
+                while (stream >> extra) {
+                        mods.extrasOn.push_back(extra);
+                }
+        }
+        return mods;
+}
+
+} // namespace
+
+namespace serializer {
+
+bool save_map(const char* path, const std::vector<spooner_graph::EntityRecord>& entities) {
+        if (path == nullptr) {
+                return false;
+        }
+        FILE* file = std::fopen(path, "wb");
+        if (!file) {
+                return false;
+        }
+        std::fprintf(file, "<SpoonerMap>\n");
+        for (const auto& entity : entities) {
+                std::fprintf(file, "  <Entity id=\"%d\" type=\"%s\">\n", entity.id, type_to_string(entity.type).c_str());
+                std::fprintf(file, "    <ModelHash>0x%08X</ModelHash>\n", entity.model);
+                std::fprintf(file,
+                             "    <PositionRotation x=\"%.4f\" y=\"%.4f\" z=\"%.4f\" pitch=\"%.4f\" roll=\"%.4f\" yaw=\"%.4f\"/>\n",
+                             entity.transform.pos.x,
+                             entity.transform.pos.y,
+                             entity.transform.pos.z,
+                             entity.transform.rot.x,
+                             entity.transform.rot.y,
+                             entity.transform.rot.z);
+                std::fprintf(file,
+                             "    <Props visible=\"%d\" collision=\"%d\" invincible=\"%d\" frozen=\"%d\" alpha=\"%d\"/>\n",
+                             entity.props.visible ? 1 : 0,
+                             entity.props.collision ? 1 : 0,
+                             entity.props.invincible ? 1 : 0,
+                             entity.props.frozen ? 1 : 0,
+                             entity.props.alpha);
+                if (entity.attachment.attached && entity.attachment.parent != 0) {
+                        const AttachSpec& spec = entity.attachment.spec;
+                        std::fprintf(file,
+                                     "    <Attachment parentId=\"%d\" bone=\"%s\" offx=\"%.4f\" offy=\"%.4f\" offz=\"%.4f\" rotx=\"%.4f\" roty=\"%.4f\" rotz=\"%.4f\" collisions=\"%d\" softPin=\"%d\"/>\n",
+                                     entity.attachment.parent,
+                                     spec.bone.c_str(),
+                                     spec.offset.x,
+                                     spec.offset.y,
+                                     spec.offset.z,
+                                     spec.rot.x,
+                                     spec.rot.y,
+                                     spec.rot.z,
+                                     spec.collisions ? 1 : 0,
+                                     spec.softPin ? 1 : 0);
+                }
+                write_vehicle_mods(file, entity.vehicleMods);
+                std::fprintf(file, "  </Entity>\n");
+        }
+        std::fprintf(file, "</SpoonerMap>\n");
+        std::fclose(file);
+        return true;
+}
+
+bool load_map(const char* path, std::vector<LoadedEntity>& entities) {
+        entities.clear();
+        if (path == nullptr) {
+                return false;
+        }
+        FILE* file = std::fopen(path, "rb");
+        if (!file) {
+                return false;
+        }
+        std::fseek(file, 0, SEEK_END);
+        long size = std::ftell(file);
+        if (size <= 0) {
+                std::fclose(file);
+                return false;
+        }
+        std::fseek(file, 0, SEEK_SET);
+        std::string buffer;
+        buffer.resize(static_cast<size_t>(size));
+        if (std::fread(&buffer[0], 1, static_cast<size_t>(size), file) != static_cast<size_t>(size)) {
+                std::fclose(file);
+                return false;
+        }
+        std::fclose(file);
+
+        size_t pos = 0;
+        while (true) {
+                size_t entityPos = buffer.find("<Entity", pos);
+                if (entityPos == std::string::npos) {
+                        break;
+                }
+                size_t headerEnd = buffer.find('>', entityPos);
+                if (headerEnd == std::string::npos) {
+                        break;
+                }
+                std::string header = buffer.substr(entityPos, headerEnd - entityPos + 1);
+                size_t closePos = buffer.find("</Entity>", headerEnd);
+                if (closePos == std::string::npos) {
+                        break;
+                }
+                std::string block = buffer.substr(headerEnd + 1, closePos - headerEnd - 1);
+
+                LoadedEntity entry;
+                entry.legacyId = parse_int(get_attribute(header, "id"));
+                entry.type = type_from_string(get_attribute(header, "type"));
+                entry.model = parse_hash(get_tag_content(block, "ModelHash"));
+
+                std::string transformSegment = get_tag_segment(block, "PositionRotation");
+                if (!transformSegment.empty()) {
+                        entry.transform.pos.x = parse_float(get_attribute(transformSegment, "x"));
+                        entry.transform.pos.y = parse_float(get_attribute(transformSegment, "y"));
+                        entry.transform.pos.z = parse_float(get_attribute(transformSegment, "z"));
+                        entry.transform.rot.x = parse_float(get_attribute(transformSegment, "pitch"));
+                        entry.transform.rot.y = parse_float(get_attribute(transformSegment, "roll"));
+                        entry.transform.rot.z = parse_float(get_attribute(transformSegment, "yaw"));
+                }
+
+                std::string propsSegment = get_tag_segment(block, "Props");
+                if (!propsSegment.empty()) {
+                        entry.props.visible = parse_bool(get_attribute(propsSegment, "visible"));
+                        entry.props.collision = parse_bool(get_attribute(propsSegment, "collision"));
+                        entry.props.invincible = parse_bool(get_attribute(propsSegment, "invincible"));
+                        entry.props.frozen = parse_bool(get_attribute(propsSegment, "frozen"));
+                        entry.props.alpha = parse_int(get_attribute(propsSegment, "alpha"));
+                }
+
+                std::string attachmentSegment = get_tag_segment(block, "Attachment");
+                if (!attachmentSegment.empty()) {
+                        entry.attachment.attached = true;
+                        entry.attachment.parent = parse_int(get_attribute(attachmentSegment, "parentId"));
+                        entry.attachment.spec.bone = get_attribute(attachmentSegment, "bone");
+                        entry.attachment.spec.offset.x = parse_float(get_attribute(attachmentSegment, "offx"));
+                        entry.attachment.spec.offset.y = parse_float(get_attribute(attachmentSegment, "offy"));
+                        entry.attachment.spec.offset.z = parse_float(get_attribute(attachmentSegment, "offz"));
+                        entry.attachment.spec.rot.x = parse_float(get_attribute(attachmentSegment, "rotx"));
+                        entry.attachment.spec.rot.y = parse_float(get_attribute(attachmentSegment, "roty"));
+                        entry.attachment.spec.rot.z = parse_float(get_attribute(attachmentSegment, "rotz"));
+                        entry.attachment.spec.collisions = parse_bool(get_attribute(attachmentSegment, "collisions"));
+                        entry.attachment.spec.softPin = parse_bool(get_attribute(attachmentSegment, "softPin"));
+                        if (entry.attachment.parent == 0) {
+                                entry.attachment.attached = false;
+                        }
+                }
+
+                entry.vehicleMods = parse_vehicle_mods(block);
+                entities.push_back(entry);
+                pos = closePos + std::strlen("</Entity>");
+        }
+
+        return !entities.empty();
+}
+
+} // namespace serializer
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/serializer_menyoo_xml.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "menyoo/spooner.hpp"
+#include "spooner_graph.hpp"
+
+namespace menyoo {
+namespace serializer {
+
+struct LoadedEntity {
+        EntityId legacyId = 0;
+        EntityType type = EntityType::Object;
+        Hash model = 0;
+        Transform transform{};
+        EntityProps props{};
+        AttachmentInfo attachment{};
+        VehicleMods vehicleMods{};
+};
+
+bool save_map(const char* path, const std::vector<spooner_graph::EntityRecord>& entities);
+bool load_map(const char* path, std::vector<LoadedEntity>& entities);
+
+} // namespace serializer
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/spooner_graph.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/spooner_graph.cpp
@@ -1,0 +1,156 @@
+#include "spooner_graph.hpp"
+
+#include <unordered_map>
+
+namespace menyoo {
+namespace {
+
+struct InternalRecord {
+        EntityType type;
+        Hash model;
+        int handle;
+        Transform transform;
+        EntityProps props;
+        AttachmentInfo attachment;
+        VehicleMods vehicleMods;
+};
+
+std::unordered_map<EntityId, InternalRecord> g_records;
+
+} // namespace
+
+namespace spooner_graph {
+
+EntityId add_entity(EntityType type, Hash model, int handle, const Transform& transform, const EntityProps& props) {
+        if (handle == 0) {
+                return 0;
+        }
+        InternalRecord record{};
+        record.type = type;
+        record.model = model;
+        record.handle = handle;
+        record.transform = transform;
+        record.props = props;
+        g_records[handle] = record;
+        return handle;
+}
+
+bool has_entity(EntityId id) {
+        return g_records.find(id) != g_records.end();
+}
+
+bool get_entity(EntityId id, EntityRecord& outRecord) {
+        auto it = g_records.find(id);
+        if (it == g_records.end()) {
+                return false;
+        }
+        const InternalRecord& record = it->second;
+        outRecord = {id, record.type, record.model, record.handle, record.transform, record.props, record.attachment, record.vehicleMods};
+        return true;
+}
+
+void update_transform(EntityId id, const Transform& transform) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                it->second.transform = transform;
+        }
+}
+
+void update_props(EntityId id, const EntityProps& props) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                it->second.props = props;
+        }
+}
+
+void update_attachment(EntityId child, EntityId parent, const AttachSpec& spec) {
+        auto it = g_records.find(child);
+        if (it != g_records.end()) {
+                it->second.attachment.attached = true;
+                it->second.attachment.parent = parent;
+                it->second.attachment.spec = spec;
+        }
+}
+
+void clear_attachment(EntityId child) {
+        auto it = g_records.find(child);
+        if (it != g_records.end()) {
+                it->second.attachment = AttachmentInfo{};
+        }
+}
+
+void set_vehicle_mods(EntityId id, const VehicleMods& mods) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                it->second.vehicleMods = mods;
+        }
+}
+
+VehicleMods get_vehicle_mods(EntityId id) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                return it->second.vehicleMods;
+        }
+        return VehicleMods{};
+}
+
+Hash model(EntityId id) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                return it->second.model;
+        }
+        return 0;
+}
+
+EntityType type(EntityId id) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                return it->second.type;
+        }
+        return EntityType::Object;
+}
+
+bool remove_entity(EntityId id) {
+        auto it = g_records.find(id);
+        if (it == g_records.end()) {
+                return false;
+        }
+        g_records.erase(it);
+        for (auto& pair : g_records) {
+                auto& attachment = pair.second.attachment;
+                if (attachment.attached && attachment.parent == id) {
+                        attachment = AttachmentInfo{};
+                }
+        }
+        return true;
+}
+
+std::vector<EntityId> list_entities() {
+        std::vector<EntityId> ids;
+        ids.reserve(g_records.size());
+        for (const auto& pair : g_records) {
+                ids.push_back(pair.first);
+        }
+        return ids;
+}
+
+std::vector<EntityRecord> snapshot() {
+        std::vector<EntityRecord> result;
+        result.reserve(g_records.size());
+        for (const auto& pair : g_records) {
+                const InternalRecord& record = pair.second;
+                result.push_back({pair.first, record.type, record.model, record.handle, record.transform, record.props, record.attachment, record.vehicleMods});
+        }
+        return result;
+}
+
+AttachmentInfo attachment(EntityId id) {
+        auto it = g_records.find(id);
+        if (it != g_records.end()) {
+                return it->second.attachment;
+        }
+        return AttachmentInfo{};
+}
+
+} // namespace spooner_graph
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/spooner_graph.hpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/menyoo_compat/spooner_graph.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <vector>
+
+#include "menyoo/spooner.hpp"
+
+namespace menyoo {
+namespace spooner_graph {
+
+struct EntityRecord {
+        EntityId id;
+        EntityType type;
+        Hash model;
+        int handle;
+        Transform transform;
+        EntityProps props;
+        AttachmentInfo attachment;
+        VehicleMods vehicleMods;
+};
+
+EntityId add_entity(EntityType type, Hash model, int handle, const Transform& transform, const EntityProps& props);
+bool has_entity(EntityId id);
+bool get_entity(EntityId id, EntityRecord& outRecord);
+void update_transform(EntityId id, const Transform& transform);
+void update_props(EntityId id, const EntityProps& props);
+void update_attachment(EntityId child, EntityId parent, const AttachSpec& spec);
+void clear_attachment(EntityId child);
+void set_vehicle_mods(EntityId id, const VehicleMods& mods);
+VehicleMods get_vehicle_mods(EntityId id);
+Hash model(EntityId id);
+EntityType type(EntityId id);
+bool remove_entity(EntityId id);
+std::vector<EntityId> list_entities();
+std::vector<EntityRecord> snapshot();
+AttachmentInfo attachment(EntityId id);
+
+} // namespace spooner_graph
+} // namespace menyoo

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/tests/spooner_min.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/tests/spooner_min.cpp
@@ -1,0 +1,45 @@
+#if MENUYO_TESTS
+
+#include "menyoo/intent_api.hpp"
+
+namespace {
+
+constexpr menyoo::Hash kAdderHash = 0xB779A091;
+constexpr menyoo::Hash kPropHash = 0x5D6B5F0B;
+
+} // namespace
+
+extern "C" void run_spooner_min_test() {
+        using namespace menyoo;
+
+        Transform vehicleTransform{};
+        vehicleTransform.pos = {0.0f, 0.0f, 75.0f};
+        vehicleTransform.rot = {0.0f, 0.0f, 0.0f};
+        EntityId vehicleId = spawn_entity(EntityType::Vehicle, kAdderHash, vehicleTransform);
+        if (vehicleId == 0) {
+                return;
+        }
+        set_entity_transform(vehicleId, vehicleTransform);
+
+        Transform propTransform{};
+        propTransform.pos = {0.0f, 0.0f, 75.0f};
+        propTransform.rot = {0.0f, 0.0f, 0.0f};
+        EntityId propId = spawn_entity(EntityType::Object, kPropHash, propTransform);
+        if (propId != 0) {
+                AttachSpec spec;
+                spec.bone = "chassis";
+                spec.offset = {0.0f, 1.0f, 0.4f};
+                attach_entity(propId, vehicleId, spec);
+        }
+
+        EntityProps props;
+        props.invincible = true;
+        props.frozen = true;
+        props.alpha = 200;
+        set_entity_props(vehicleId, props);
+
+        save_map("/data/spooner.xml");
+        load_map("/data/spooner.xml");
+}
+
+#endif // MENUYO_TESTS

--- a/2-LushModz-1.38-Menu-Base2/gtaPayload/source/ui/page_spooner.cpp
+++ b/2-LushModz-1.38-Menu-Base2/gtaPayload/source/ui/page_spooner.cpp
@@ -1,0 +1,514 @@
+#include "ui/page_spooner.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "Functions.h"
+#include "MenuUtils.h"
+#include "Enums.h"
+#include "natives.h"
+
+namespace menyoo {
+namespace ui {
+namespace {
+
+std::vector<EntityId> g_entities;
+int g_selectedIndex = -1;
+EntityId g_selectedId = 0;
+EntityId g_lastSelection = 0;
+EntityProps g_selectedProps{};
+Transform g_selectedTransform{};
+AttachmentInfo g_selectedAttachment{};
+AttachSpec g_attachSpec{};
+EntityId g_attachParent = 0;
+std::string g_modelInput = "0xB779A091";
+std::string g_mapName = "spooner.xml";
+uint32_t g_lastMoveTick = 0;
+
+const float kMoveStep = 0.25f;
+const float kRotStep = 5.0f;
+const uint32_t kMoveIntervalMs = 120;
+
+const char* TypeName(EntityType type) {
+        switch (type) {
+        case EntityType::Vehicle:
+                return "Vehicle";
+        case EntityType::Ped:
+                return "Ped";
+        case EntityType::Object:
+        default:
+                return "Object";
+        }
+}
+
+Hash ParseModel(const std::string& input) {
+        if (input.empty()) {
+                return 0;
+        }
+        bool isHex = input.size() > 2 && input[0] == '0' && (input[1] == 'x' || input[1] == 'X');
+        auto isDecimal = [](const std::string& value) {
+                if (value.empty()) {
+                        return false;
+                }
+                for (char ch : value) {
+                        if (ch < '0' || ch > '9') {
+                                return false;
+                        }
+                }
+                return true;
+        };
+        bool numeric = isHex;
+        if (!isHex) {
+                numeric = isDecimal(input);
+        }
+        if (isHex || numeric) {
+                int base = isHex ? 16 : 10;
+                return static_cast<Hash>(std::strtoul(input.c_str(), nullptr, base));
+        }
+        return GET_HASH_KEY(input.c_str());
+}
+
+void ToLowerInPlace(std::string& value) {
+        for (char& ch : value) {
+                if (ch >= 'A' && ch <= 'Z') {
+                        ch = static_cast<char>(ch - 'A' + 'a');
+                }
+        }
+}
+
+bool PromptKeyboard(const char* title, std::string& value, size_t maxLen) {
+        DISPLAY_ONSCREEN_KEYBOARD(1, title, "", value.c_str(), "", "", "", static_cast<int>(maxLen));
+        while (true) {
+                int status = UPDATE_ONSCREEN_KEYBOARD();
+                if (status == 0) {
+                        WAIT(0);
+                        continue;
+                }
+                if (status == 1) {
+                        const char* result = GET_ONSCREEN_KEYBOARD_RESULT();
+                        if (result != nullptr) {
+                                value = result;
+                        }
+                        return true;
+                }
+                return false;
+        }
+}
+
+void UpdateSelectionState(bool forceAttachment) {
+        if (g_selectedId == 0) {
+                g_selectedProps = EntityProps{};
+                g_selectedTransform = Transform{};
+                g_selectedAttachment = AttachmentInfo{};
+                return;
+        }
+        g_selectedProps = get_entity_props(g_selectedId);
+        g_selectedTransform = get_entity_transform(g_selectedId);
+        g_selectedAttachment = get_attachment(g_selectedId);
+        if (forceAttachment || g_lastSelection != g_selectedId) {
+                if (g_selectedAttachment.attached) {
+                        g_attachParent = g_selectedAttachment.parent;
+                        g_attachSpec = g_selectedAttachment.spec;
+                } else {
+                        g_attachParent = 0;
+                        g_attachSpec = AttachSpec{};
+                }
+        }
+        g_lastSelection = g_selectedId;
+}
+
+void RefreshEntities(bool forceState) {
+        EntityId previousId = g_selectedId;
+        g_entities = list_entities();
+        if (g_entities.empty()) {
+                g_selectedIndex = -1;
+                g_selectedId = 0;
+                UpdateSelectionState(true);
+                return;
+        }
+        if (previousId != 0) {
+                auto it = std::find(g_entities.begin(), g_entities.end(), previousId);
+                if (it != g_entities.end()) {
+                        g_selectedIndex = static_cast<int>(std::distance(g_entities.begin(), it));
+                }
+        }
+        if (g_selectedIndex < 0 || g_selectedIndex >= static_cast<int>(g_entities.size())) {
+                g_selectedIndex = 0;
+        }
+        g_selectedId = g_entities[g_selectedIndex];
+        UpdateSelectionState(forceState || previousId != g_selectedId);
+}
+
+void SpawnEntityOfType(EntityType type) {
+        Hash model = ParseModel(g_modelInput);
+        if (model == 0) {
+                print("~r~Invalid model hash");
+                return;
+        }
+        vector3 playerPos = GET_ENTITY_COORDS(PLAYER_PED_ID(), false);
+        float heading = GET_ENTITY_HEADING(PLAYER_PED_ID());
+        Transform transform{};
+        transform.pos = {playerPos.x, playerPos.y, playerPos.z};
+        transform.rot = {0.0f, 0.0f, heading};
+        EntityId newId = spawn_entity(type, model, transform);
+        if (newId == 0) {
+                print("~r~Spawn failed");
+                return;
+        }
+        g_selectedId = newId;
+        g_selectedIndex = -1;
+        RefreshEntities(true);
+}
+
+void CloneSelected() {
+        if (g_selectedId == 0) {
+                return;
+        }
+        EntityType type = entity_type(g_selectedId);
+        Hash model = entity_model(g_selectedId);
+        if (model == 0) {
+                return;
+        }
+        Transform transform = g_selectedTransform;
+        transform.pos.y += 2.0f;
+        EntityId newId = spawn_entity(type, model, transform);
+        if (newId == 0) {
+                return;
+        }
+        set_entity_props(newId, g_selectedProps);
+        g_selectedId = newId;
+        g_selectedIndex = -1;
+        RefreshEntities(true);
+}
+
+void DeleteSelected() {
+        if (g_selectedId == 0) {
+                return;
+        }
+        if (delete_entity(g_selectedId)) {
+                g_selectedId = 0;
+                g_selectedIndex = -1;
+                RefreshEntities(true);
+        }
+}
+
+std::vector<EntityId> ParentChoices() {
+        std::vector<EntityId> choices;
+        choices.push_back(0);
+        for (EntityId id : g_entities) {
+                if (id != g_selectedId) {
+                        choices.push_back(id);
+                }
+        }
+        return choices;
+}
+
+void CycleParent(int direction) {
+        std::vector<EntityId> choices = ParentChoices();
+        if (choices.empty()) {
+                g_attachParent = 0;
+                return;
+        }
+        auto it = std::find(choices.begin(), choices.end(), g_attachParent);
+        int index = 0;
+        if (it != choices.end()) {
+                index = static_cast<int>(std::distance(choices.begin(), it));
+        }
+        int count = static_cast<int>(choices.size());
+        index = (index + direction + count) % count;
+        g_attachParent = choices[index];
+}
+
+void ApplyAttachment() {
+        if (g_selectedId == 0 || g_attachParent == 0 || g_attachParent == g_selectedId) {
+                return;
+        }
+        attach_entity(g_selectedId, g_attachParent, g_attachSpec);
+        UpdateSelectionState(true);
+}
+
+void DetachSelected() {
+        if (g_selectedId == 0) {
+                return;
+        }
+        detach_entity(g_selectedId);
+        g_attachParent = 0;
+        g_attachSpec = AttachSpec{};
+        UpdateSelectionState(true);
+}
+
+void HandleSelectionCycling(int optionIndex) {
+        if (currentOption != optionIndex || g_entities.empty()) {
+                return;
+        }
+        bool changed = false;
+        if (leftPress) {
+                g_selectedIndex--;
+                if (g_selectedIndex < 0) {
+                        g_selectedIndex = static_cast<int>(g_entities.size()) - 1;
+                }
+                leftPress = false;
+                changed = true;
+        }
+        if (rightPress) {
+                g_selectedIndex++;
+                if (g_selectedIndex >= static_cast<int>(g_entities.size())) {
+                        g_selectedIndex = 0;
+                }
+                rightPress = false;
+                changed = true;
+        }
+        if (changed) {
+                g_selectedId = g_entities[g_selectedIndex];
+                UpdateSelectionState(true);
+        }
+}
+
+void HandleParentCycling(int optionIndex) {
+        if (currentOption != optionIndex) {
+                return;
+        }
+        if (leftPress) {
+                        CycleParent(-1);
+                        leftPress = false;
+        }
+        if (rightPress) {
+                        CycleParent(1);
+                        rightPress = false;
+        }
+}
+
+} // namespace
+
+void DrawSpoonerMenu() {
+        RefreshEntities(false);
+        subTitle("Spooner");
+
+        char buffer[128];
+        std::snprintf(buffer, sizeof(buffer), "Model Hash: %s", g_modelInput.c_str());
+        addOption(buffer);
+        int modelOption = optionCount;
+
+        addOption("Spawn Vehicle");
+        int spawnVehicleOption = optionCount;
+
+        addOption("Spawn Ped");
+        int spawnPedOption = optionCount;
+
+        addOption("Spawn Object");
+        int spawnObjectOption = optionCount;
+
+        const char* selectedType = g_selectedId != 0 ? TypeName(entity_type(g_selectedId)) : "None";
+        if (g_selectedId != 0) {
+                std::snprintf(buffer, sizeof(buffer), "Selected: %s %d", selectedType, g_selectedId);
+        } else {
+                std::snprintf(buffer, sizeof(buffer), "Selected: <none>");
+        }
+        addOption(buffer);
+        int selectOption = optionCount;
+
+        addOption("Clone Selected");
+        int cloneOption = optionCount;
+
+        addOption("Delete Selected");
+        int deleteOption = optionCount;
+
+        int freezeOption = -1;
+        int invincibleOption = -1;
+        int alphaOption = -1;
+        int parentOption = -1;
+        int boneOption = -1;
+        int collisionsOption = -1;
+        int softPinOption = -1;
+        int applyAttachmentOption = -1;
+        int detachOption = -1;
+
+        int mapNameOption = -1;
+        int saveOption = -1;
+        int loadOption = -1;
+
+        if (g_selectedId != 0) {
+                CheckBox("Freeze", g_selectedProps.frozen);
+                freezeOption = optionCount;
+                CheckBox("Invincible", g_selectedProps.invincible);
+                invincibleOption = optionCount;
+                int prevAlpha = g_selectedProps.alpha;
+                addIntOption("Alpha", &g_selectedProps.alpha, 0, 255, false);
+                alphaOption = optionCount;
+                if (prevAlpha != g_selectedProps.alpha) {
+                        set_entity_props(g_selectedId, g_selectedProps);
+                }
+
+                char parentLabel[64];
+                if (g_attachParent == 0) {
+                        std::snprintf(parentLabel, sizeof(parentLabel), "Attachment Parent: None");
+                } else {
+                        std::snprintf(parentLabel, sizeof(parentLabel), "Attachment Parent: %d", g_attachParent);
+                }
+                addOption(parentLabel);
+                parentOption = optionCount;
+
+                std::snprintf(buffer, sizeof(buffer), "Attachment Bone: %s", g_attachSpec.bone.empty() ? "<none>" : g_attachSpec.bone.c_str());
+                addOption(buffer);
+                boneOption = optionCount;
+
+                addFloatOption("Offset X", &g_attachSpec.offset.x, -50.0f, 50.0f, false);
+                addFloatOption("Offset Y", &g_attachSpec.offset.y, -50.0f, 50.0f, false);
+                addFloatOption("Offset Z", &g_attachSpec.offset.z, -50.0f, 50.0f, false);
+
+                addFloatOption("Rotation X", &g_attachSpec.rot.x, -360.0f, 360.0f, false);
+                addFloatOption("Rotation Y", &g_attachSpec.rot.y, -360.0f, 360.0f, false);
+                addFloatOption("Rotation Z", &g_attachSpec.rot.z, -360.0f, 360.0f, false);
+
+                CheckBox("Attachment Collisions", g_attachSpec.collisions);
+                collisionsOption = optionCount;
+                CheckBox("Attachment Soft Pin", g_attachSpec.softPin);
+                softPinOption = optionCount;
+
+                addOption("Apply Attachment");
+                applyAttachmentOption = optionCount;
+
+                addOption("Detach");
+                detachOption = optionCount;
+        }
+
+        std::snprintf(buffer, sizeof(buffer), "Map File: %s", g_mapName.c_str());
+        addOption(buffer);
+        mapNameOption = optionCount;
+
+        addOption("Save Map");
+        saveOption = optionCount;
+
+        addOption("Load Map");
+        loadOption = optionCount;
+
+        HandleSelectionCycling(selectOption);
+        if (parentOption != -1) {
+                HandleParentCycling(parentOption);
+        }
+
+        int pressed = GET();
+        if (pressed == modelOption) {
+                if (PromptKeyboard("MODEL", g_modelInput, 64)) {
+                        ToLowerInPlace(g_modelInput);
+                }
+        } else if (pressed == spawnVehicleOption) {
+                SpawnEntityOfType(EntityType::Vehicle);
+        } else if (pressed == spawnPedOption) {
+                SpawnEntityOfType(EntityType::Ped);
+        } else if (pressed == spawnObjectOption) {
+                SpawnEntityOfType(EntityType::Object);
+        } else if (pressed == cloneOption) {
+                CloneSelected();
+        } else if (pressed == deleteOption) {
+                DeleteSelected();
+        } else if (pressed == freezeOption) {
+                g_selectedProps.frozen = !g_selectedProps.frozen;
+                set_entity_props(g_selectedId, g_selectedProps);
+        } else if (pressed == invincibleOption) {
+                g_selectedProps.invincible = !g_selectedProps.invincible;
+                set_entity_props(g_selectedId, g_selectedProps);
+        } else if (pressed == boneOption) {
+                PromptKeyboard("BONE", g_attachSpec.bone, 32);
+        } else if (pressed == collisionsOption) {
+                g_attachSpec.collisions = !g_attachSpec.collisions;
+        } else if (pressed == softPinOption) {
+                g_attachSpec.softPin = !g_attachSpec.softPin;
+        } else if (pressed == applyAttachmentOption) {
+                ApplyAttachment();
+        } else if (pressed == detachOption) {
+                DetachSelected();
+        } else if (pressed == mapNameOption) {
+                PromptKeyboard("MAP", g_mapName, 64);
+        } else if (pressed == saveOption) {
+                if (save_map(g_mapName.c_str())) {
+                        print("~g~Map saved");
+                } else {
+                        print("~r~Save failed");
+                }
+        } else if (pressed == loadOption) {
+                if (load_map(g_mapName.c_str())) {
+                        print("~g~Map loaded");
+                        RefreshEntities(true);
+                } else {
+                        print("~r~Load failed");
+                }
+        }
+}
+
+bool HandleSpoonerControls() {
+        if (g_selectedId == 0) {
+                return false;
+        }
+        bool up = IS_DISABLED_CONTROL_PRESSED(0, INPUT_SCRIPT_PAD_UP);
+        bool down = IS_DISABLED_CONTROL_PRESSED(0, INPUT_SCRIPT_PAD_DOWN);
+        bool left = IS_DISABLED_CONTROL_PRESSED(0, INPUT_SCRIPT_PAD_LEFT);
+        bool right = IS_DISABLED_CONTROL_PRESSED(0, INPUT_SCRIPT_PAD_RIGHT);
+        if (!up && !down && !left && !right) {
+                return false;
+        }
+        bool l1 = IS_DISABLED_CONTROL_PRESSED(0, INPUT_FRONTEND_LB);
+        bool r1 = IS_DISABLED_CONTROL_PRESSED(0, INPUT_FRONTEND_RB);
+        uint32_t now = GET_GAME_TIMER();
+        if (now - g_lastMoveTick < kMoveIntervalMs) {
+                return true;
+        }
+        g_lastMoveTick = now;
+        Transform transform = get_entity_transform(g_selectedId);
+        bool moved = false;
+        if (l1) {
+                if (left) {
+                        transform.rot.z -= kRotStep;
+                        moved = true;
+                }
+                if (right) {
+                        transform.rot.z += kRotStep;
+                        moved = true;
+                }
+                if (up) {
+                        transform.rot.x += kRotStep;
+                        moved = true;
+                }
+                if (down) {
+                        transform.rot.x -= kRotStep;
+                        moved = true;
+                }
+        } else if (r1) {
+                if (left) {
+                        transform.rot.y -= kRotStep;
+                        moved = true;
+                }
+                if (right) {
+                        transform.rot.y += kRotStep;
+                        moved = true;
+                }
+        } else {
+                if (up) {
+                        transform.pos.z += kMoveStep;
+                        moved = true;
+                }
+                if (down) {
+                        transform.pos.z -= kMoveStep;
+                        moved = true;
+                }
+                if (left) {
+                        transform.pos.x -= kMoveStep;
+                        moved = true;
+                }
+                if (right) {
+                        transform.pos.x += kMoveStep;
+                        moved = true;
+                }
+        }
+        if (moved) {
+                set_entity_transform(g_selectedId, transform);
+                g_selectedTransform = transform;
+        }
+        return moved;
+}
+
+} // namespace ui
+} // namespace menyoo


### PR DESCRIPTION
## Summary
- add the Menyoo Spooner surface with spawn, attachment, persistence, and capability APIs plus PS4 bridge wiring
- integrate the Spooner UI page into the main menu and centralize entity movement handling through the new intent layer
- expand the build to cover the new compatibility units and ensure object directories are created automatically

## Testing
- `make` *(fails: missing native wrappers/types when building the legacy PS4 sources)*

------
https://chatgpt.com/codex/tasks/task_e_68e12e1c4ff0833186125f16d849f7af